### PR TITLE
deleted applicationIdSuffix for debug build variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,10 +40,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            applicationIdSuffix ".debug"
-        }
-
         release {
             minifyEnabled true
             shrinkResources true


### PR DESCRIPTION
deleted applicationIdSuffix for debug build variant because VK doesn't allow to register a few apps with the common package name